### PR TITLE
Add tracked bodies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ python viewer.py <scene_file.xml>
 pip install mujoco
 ```
 
+### Tracked objects
+
+It is possible to obtain the real-time pose of objects in the Mujoco scene via the Client SDK. 
+
+To do this, you must add this parameter to the scene's XML file:
+
+```xml
+    <custom>
+        <text name="tracked_bodies" data="body_name1, body_name2, body_name3" />
+    </custom>
+```
+
+In the data, you can note down the body name of the objects you want to track, as many as you like.
+In the available scenes, this setting is already there, but you can change the tracked objects as you see fit. 
+
+
 ---
 ### Credits
 

--- a/objects/kitchen_body.xml
+++ b/objects/kitchen_body.xml
@@ -742,7 +742,7 @@
             <geom name="stack_1_main_group_4_door_door_visual" size="0.2485 0.1035 0.015" quat="0.707105 0.707108 0 0" type="box" contype="0" conaffinity="0" group="1" mass="0" material="stack_1_main_group_4_door_mat"/>
             <site name="stack_1_main_group_4_door_default_site" pos="0 0 0" size="0.002" rgba="1 0 0 0"/>
             <!-- 1er tiroir -->
-            <body name="stack_1_main_group_4_door_handle_main">
+            <body name="drawer_handle_1">
                 <geom name="stack_1_main_group_4_door_handle_handle" size="0.013 0.0635" pos="0 -0.05 0" quat="0.707105 0 0.707108 0" type="cylinder" density="10" rgba="0.5 0 0 1" group="3"  friction="1.0 0.05 0.002" margin="0.005" solimp="0.98 0.99 0.001" solref="0.002 1"/>
                 <geom name="stack_1_main_group_4_door_handle_handle_connector_top" size="0.008 0.025" pos="0.0381 -0.025 0" quat="0.707107 0.707107 0 0" type="cylinder" density="10" rgba="0.5 0 0 1" group="3"/>
                 <geom name="stack_1_main_group_4_door_handle_handle_connector_bottom" size="0.008 0.025" pos="-0.0381 -0.025 0" quat="0.707107 0.707107 0 0" type="cylinder" density="10" rgba="0.5 0 0 1" group="3"/>

--- a/scenes/base_scene.xml
+++ b/scenes/base_scene.xml
@@ -1,7 +1,11 @@
 <mujoco model="reachy2 base_scene">
 	<compiler angle="radian"/>
 
-	<include file="../assets/reachy2_asset.xml" />
+	<custom>
+        <text name="tracked_bodies" data="torso"/>
+    </custom>
+
+	<include file="../assets/reachy2_asset.xml"/>
 
 	<option impratio="5">
 		<flag multiccd="enable"/>

--- a/scenes/fruits_scene.xml
+++ b/scenes/fruits_scene.xml
@@ -7,6 +7,10 @@
     <include file="../assets/plate_asset.xml"/>
     <include file="../assets/table_asset.xml"/>
 
+    <custom>
+        <text name="tracked_bodies" data="torso, apple1, apple2, orange1, orange2" />
+    </custom>
+
     <default>
         <default class="ycb_col">
             <geom contype="1" rgba = "1 1 1 1" conaffinity="1" condim ="6" solimp="0.95 0.99 0.001" solref=".002 1" margin = "0.002" friction="0.5 0.1 0.01" group = "3"/>

--- a/scenes/kitchen_scene.xml
+++ b/scenes/kitchen_scene.xml
@@ -1,6 +1,10 @@
 <mujoco model="reachy2 kitchen_scene">
     <compiler angle="radian"/>
 
+    <custom>
+        <text name="tracked_bodies" data="torso, fork, knife, cup, plate, drawer_handle_1" />
+    </custom>
+
     <include file="../assets/reachy2_asset.xml"/>
     <include file="../assets/kitchen_asset.xml"/>
     <include file="../assets/table_asset.xml"/>

--- a/scenes/table_scene.xml
+++ b/scenes/table_scene.xml
@@ -1,6 +1,10 @@
 <mujoco model="reachy2 table_scene">
 	<compiler angle="radian"/>
 
+	<custom>
+        <text name="tracked_bodies" data="torso, cube" />
+    </custom>
+
 	<include file="../assets/reachy2_asset.xml" />
 	<include file="../assets/simpleTable_asset.xml"/>
 
@@ -39,7 +43,7 @@
 			<include file="../objects/simpleWoodTable_body.xml" />
 		</body>
 
-		<body name="goal" pos="0.45 -0.4 0.65">
+		<body name="cube" pos="0.45 -0.4 0.65">
 			<freejoint name="box"/>
 			<geom type="box" size="0.025 0.025 0.025" rgba="1.0 0 0 1" conaffinity="1" contype="1" mass="0.05" friction="1.0 0.5 0.01" priority="1"/>
 		</body>


### PR DESCRIPTION
**Goes with the SDK Client PR : https://github.com/pollen-robotics/reachy2-sdk/pull/553**

Add of tracked bodies in scenes. 

**Goes with branches:**
- [237 of reachy2_sdk_server](https://github.com/pollen-robotics/reachy2_sdk_server/tree/237-add-access-to-item-poses-in-mujoco-scenes) 
- [552 of reachy2-sdk](https://github.com/pollen-robotics/reachy2-sdk/tree/552-add-access-to-item-poses-in-mujoco-scenes)
- [188 of reachy2-sdk-api](https://github.com/pollen-robotics/reachy2-sdk-api/tree/188-add-access-to-item-poses-in-mujoco-scenes)